### PR TITLE
Fix behaviour for brep files without metadata

### DIFF
--- a/src/Geom/GeometryReader.h
+++ b/src/Geom/GeometryReader.h
@@ -274,7 +274,8 @@ namespace Geom
             typedef uint64_t UniqueIdType;
             json metadata;
             std::unordered_map<uint64_t, json> gpMap;
-            if (this->myConfig.contains("metadataFileName"))
+            if (this->myConfig.contains("metadataFileName")
+                && !this->myConfig["metadataFileName"].is_null())
             {
                 std::string mfile = this->myConfig["metadataFileName"];
                 if (not fs::exists(mfile))


### PR DESCRIPTION
When attempting to process a brep file which did not have an associated metadata file, there was an obscure error:

>  RuntimeError: [json.exception.type_error.302] type must be string, but is null

With this fix, there is now a warning that no metadata has been provided, and then PPP continues.

Checklist
- [x] Source is rebased on latest `upstream main` so is mergeable automatically or easily merged even with confliction.
- [x] Title of this PR is meaningful: e.g. "fix issue #8 geomPipeline.py -o does not work", not "fix geomPipeline.py"
- [x] Commit message is meaningful:  `git push origin +your_branch` to squash some tiny fixes for CI failures
- [x] Give the maintainer the legal rights to change the open source license in the future (see wiki/Contribution.md) for details


