### PR TITLE
geometry scale and output unit (issue 22)

### DIFF
--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -47,6 +47,11 @@ geomPipeline.py ../data/test_geometry/test_geometry.stp -o test_geometry_result.
 geomPipeline.py check ../data/test_geometry/test_geometry_manifest.json --verbosity WARNING
 if [ ! $? -eq 0 ] ; then   echo "Error during geometry test" ;  exit 1 ; fi
 
+# test scaling, output to a diff output folder
+geomPipeline.py imprint ../data/test_geometry/test_geometry.stp -o /tmp/test_geometry_scaled.brep --output-unit M
+geomPipeline.py imprint ../data/test_geometry/test_geometry.stp --working-dir /tmp/ -o test_geometry_scaled.stp --output-unit M
+if [ ! $? -eq 0 ] ; then   echo "Error during geometry output unit (scaling) test " ;  exit 1 ; fi
+
 # test single thread mode, only for non-coupled operations
 geomPipeline.py check ../data/test_geometry/test_geometry.stp --thread-count 1 --verbosity WARNING
 if [ ! $? -eq 0 ] ; then   echo "Error during geometry test in single thread mode" ;  exit 1 ; fi

--- a/src/Geom/GeometryPropertyBuilder.h
+++ b/src/Geom/GeometryPropertyBuilder.h
@@ -76,8 +76,8 @@ namespace Geom
         {
             // max and min volume check!
             double max_volume = 0;
-            double min_volume = 1e100;
-            double max_volume_threshold = 1e16; // todo: get from config
+            double min_volume = 1e100;  //  unit is mm^3
+            double max_volume_threshold = 1e16; // todo: get from config parameter
             for (size_t i = 0; i < myInputData->itemCount(); i++)
             {
                 const auto& p = myGeometryProperties[i];

--- a/src/Geom/GeometryTypes.h
+++ b/src/Geom/GeometryTypes.h
@@ -152,7 +152,7 @@ namespace Geom
             return ShapeErrorType::NoError;
     }
 
-    class CollisionInfo
+    struct CollisionInfo
     {
     public:
         ItemIndexType first;
@@ -161,6 +161,14 @@ namespace Geom
         CollisionType type;
 
         CollisionInfo() = default;
+        // C++20 prevents conversion form <brace-enclosed initializer list> to this type
+        CollisionInfo(ItemIndexType _first, ItemIndexType _second, double _value, CollisionType _type)
+                : first(_first)
+                , second(_second)
+                , value(_value)
+                , type(_type)
+        {
+        }
     };
     inline void to_json(json& j, const CollisionInfo& p)
     {

--- a/src/Geom/OccUtils.h
+++ b/src/Geom/OccUtils.h
@@ -111,9 +111,14 @@ namespace Geom
         GeomExport TopoDS_Shape fuseShape(const VectorType<TopoDS_Shape> v, bool occInternalParallel = true);
         GeomExport TopoDS_Shape cutShape(const TopoDS_Shape& from, const TopoDS_Shape& substractor);
 
+        /// surface mesh
         GeomExport std::shared_ptr<BRepMesh_IncrementalMesh> meshShape(const TopoDS_Shape& aShape,
                                                                        double resolution = 0.01);
+        /// save to STL mesh format
         GeomExport Standard_Boolean saveMesh(TopoDS_Shape& aShape, const std::string file_name);
+
+        /// scale up or down shape
+        GeomExport TopoDS_Shape scaleShape(const TopoDS_Shape& from, double scale, const gp_Pnt origin = gp_Pnt());
 
     } // namespace OccUtils
 

--- a/src/Geom/ProcessorSample.h
+++ b/src/Geom/ProcessorSample.h
@@ -32,7 +32,9 @@ namespace Geom
         ~ProcessorSample() = default;
 
         /**
-         * \brief preparing work in serial mode
+         * \brief preparing work in serial mode,
+         * memory allocation must been done in serial mode, there may be lock in allocator
+         * memory allocation is processItem() is forbidden
          */
         virtual void prepareInput() override final
         {

--- a/src/PPP/CoreTests/CMakeLists.txt
+++ b/src/PPP/CoreTests/CMakeLists.txt
@@ -1,17 +1,15 @@
 # https://github.com/catchorg/Catch2/blob/master/docs/cmake-integration.md
 # catch2 must be a subfolder, so `add_subdirectory` is done in toplevel cmakelists.txt
-#add_subdirectory(./Catch2)
 
-# std can and should be applied to target only
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# if C++17 is not available, then conditionally turn off one test
+#set(CMAKE_CXX_STANDARD 17)
+#set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 
 #########################################
 find_package(Threads)
-# -pthread  option is not portable
-#SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")  # not portable
-#target_link_libraries(MyApp ${CMAKE_THREAD_LIBS_INIT}) # portable
+# NOTE: -pthread  option is not portable
+# target_link_libraries(MyApp ${CMAKE_THREAD_LIBS_INIT}) # portable
 
 #file(GLOB TEST_SOURCES "*est*.cpp")  # not recommended way to find source
 set(APP_TEST_SOURCES 
@@ -23,7 +21,6 @@ add_executable(app_tests ${APP_TEST_SOURCES})
 set_target_properties(app_tests PROPERTIES OUTPUT_NAME "pppAppTests")
 target_link_libraries(app_tests ${CMAKE_THREAD_LIBS_INIT}) # For pthreads, portable
 
-#add_dependencies(app_tests MyBase)
 target_link_libraries(app_tests MyBase)
 target_link_libraries(app_tests MyApp)
 target_link_libraries(app_tests Catch2::Catch2)
@@ -33,7 +30,7 @@ target_link_libraries(app_tests Catch2::Catch2)
 set(PARALLEL_TEST_SOURCES 
   "ParallelAccessorTest.cpp"
 )
-# Now simply link against gtest or gtest_main as needed. Eg
+
 add_executable(parallel_tests ${PARALLEL_TEST_SOURCES})
 set_target_properties(parallel_tests PROPERTIES OUTPUT_NAME "pppParallelTests")
 
@@ -45,10 +42,6 @@ target_link_libraries(parallel_tests ${TBB_LIBRARIES})
 if(MSVC)
     target_compile_options(parallel_tests PRIVATE  /wd4251 /wd4275 )
 endif()
-
-# if in catch2 test mode in the future, uncomment this line below
-#target_link_libraries(parallel_tests Catch2::Catch2)
-##########################################################
 
 ######################### test registration #####################
 #  using contrib/Catch.cmake, ParseAndAddCatchTests.cmake

--- a/src/PPP/TypeDefs.h
+++ b/src/PPP/TypeDefs.h
@@ -66,6 +66,12 @@ namespace PPP
     template <class Item> using VectorType = std::vector<Item>;
 
     /**
+     * Sparse vector, based on shared_ptr, initialize value and set size before usage
+     * e.g. `mySpVec<std::vector<double>>`
+     * */
+    template <class Item> using SparseVector = std::vector<std::shared_ptr<Item>>;
+
+    /**
      * MapType choice for parallel preprocessor
      * std::set or std::map, based on binary tree, has time complexity O(logN) for find and insert
      * while unordered_map and unorderred_set, based on hash, can reserve space (crucial).

--- a/src/python/geomPipeline.py
+++ b/src/python/geomPipeline.py
@@ -89,6 +89,22 @@ def geom_add_argument(parser):
         action="store_true",
         help="ignore failed (in BOP check, collision detect, etc) solids",
     )
+
+    # it is not arbitrary scaling, but can change output units (m, cm, mm) of STEP file format
+    parser.add_argument(
+        "-ou", "--output-unit",
+        dest="output_unit",
+        type=str,
+        help="output geometry unit, by default, `MM` for CAD, change unit will cause scaling when read back",
+    )
+
+    # it is not arbitrary scaling, but can change output units (m, cm, mm) of STEP file format
+    parser.add_argument(
+        "--input-unit",
+        dest="input_unit",
+        type=str,
+        help="input geometry unit, by default, only needed for brep file without meta data for length ",
+    )
     return parser
 
 
@@ -144,6 +160,16 @@ ignoreFailed = False
 if args.ignore_failed != None and args.ignore_failed:
     ignoreFailed = True
 
+outputUnit = "MM"  # argument can be capital or uncapital letter
+if args.output_unit:
+    if args.output_unit.upper() in ("MM", "CM", "M", "INCH"):  # STEP supported units
+        outputUnit = args.output_unit.upper()
+
+# in CAD, the default lengths unit is MM (millimeter)
+inputUnit = "MM"
+if args.input_unit:
+    if args.input_unit.upper() in ("MM", "CM", "M", "INCH"):  # STEP supported units
+        inputUnit = args.input_unit.upper()
 
 if debugging > 0:
     print("action on the geometry is ", args.action)
@@ -183,7 +209,12 @@ writers = [
             "value": mergeResultShapes,
             "doc": "control whether imprinted solids will be merged (remove duplicate faces) before write-out",
         },
-        "doc": "if no directory part in `outputFile`, saved into the case `outputDir`",
+        "outputUnit": {
+            "type": "string",
+            "value": outputUnit,
+            "doc": "control output geometry length unit, for CAD, default mm",
+        },
+        "doc": "if no directory part in `outputFile`, saved into the case `outputDir` folder",
     }
 ]
 

--- a/src/python/geomPipeline.py
+++ b/src/python/geomPipeline.py
@@ -130,6 +130,7 @@ outputFile = case_name + "_processed.brep"  # saved to case output folder
 if args.outputFile:
     outputFile = args.outputFile
     print("args.outputFile = ", args.outputFile)
+outputFile = os.path.abspath(outputFile)
 
 # output metadata filename
 outputMetadataFile = outputFile[: outputFile.rfind(".")] + "_metadata.json"
@@ -143,7 +144,7 @@ if args.metadata:
     else:
         raise IOError("input metadata file does not exist: ", args.metadata)
 else:
-    if inputFile.find(".brep") > 0 or inputFile.find(".brp"):
+    if inputFile.endswith(".brep")  or inputFile.endswith(".brp"):
         inputMetadataFile = inputFile[: inputFile.rfind(".")] + "_metadata.json"
         if os.path.exists(inputMetadataFile):
             hasInputMetadataFile = True
@@ -195,7 +196,7 @@ readers = [  # it is possible to have multiple Reader instances in this list
     {
         "className": "Geom::GeometryReader",
         "dataFileName": inputFile,
-        "metadataFileName": None if not hasInputMetadataFile else inputMetadataFile,
+        "metadataFileName": None if not hasInputMetadataFile else os.path.abspath(inputMetadataFile),
         "doc": "only step, iges, FCStd, brep+json metadata are supported",
     }
 ]

--- a/src/python/pppPipelineController.py
+++ b/src/python/pppPipelineController.py
@@ -108,15 +108,16 @@ def ppp_parse_input(args):
             # download to current folder
             import urllib.request
 
-            urllib.request.urlretrieve(args.input, "input_data")
-            return "input_data"
+            urllib.request.urlretrieve(args.input, "downloaded_input_data")
+            args.input = os.path.abspath("downloaded_input_data")
 
         elif os.path.exists(args.input):
-            return os.path.abspath(args.input)  # must be abspath, as current dir may change
+            args.input = os.path.abspath(args.input)
         else:
             raise IOError("input file does not exist: ", args.input)
     else:
         raise Exception("input file must be given as an argument")
+    return args.input  # must be abspath, as current dir may change
 
 
 def ppp_check_argument(args):
@@ -127,9 +128,8 @@ def ppp_check_argument(args):
         else:
             args.thread_count = cpu_count()  # can set args.value just like a dict
     if not args.workingDir:
-        args.workingDir = "./"  # debug and config file will be put here,
+        args.workingDir = os.path.abspath("./")  # debug and config file will be put here,
         # before copy to outputDir at the end of processing in C++ Context::finalize()
-    # print(args.thread_count)
 
 
 ####################################################################

--- a/src/python/pppPipelineController.py
+++ b/src/python/pppPipelineController.py
@@ -56,7 +56,7 @@ def ppp_add_argument(parser):
     )
 
     parser.add_argument(
-        "-o", "--output-file", help="output file name relative to output-dir or absolute path",
+        "-o", "--output-file", help="output file name relative to working-dir or absolute path",
         dest = "outputFile"
     )
 

--- a/wiki/GetStarted.md
+++ b/wiki/GetStarted.md
@@ -20,8 +20,6 @@ Optional arguments for all pipelines:
                         output file name (without folder path)
   --working-dir WORKING_DIR
                         working folder path, by default the current working folder
-  --output-dir OUTPUT_DIR
-                        output folder path, by default, a subfolder in workingDir
   --config              only generate config.json without run the pipeline
 
   -nt THREAD_COUNT, --thread-count THREAD_COUNT


### PR DESCRIPTION

output unit only make sense if  output file is brep.  

 step has metadata. of unit.    change this unit will cause scaling during read back.  so it is best is keep the unit as MM, to not confuse.  this is default well-accepted.

For brep,  --output-unit M   will trigger the geometry scaling. assuming input unit is MM

A readme is under writing.

scaling is done in serial mode. have not try scaling on large geometry, but I will try.




<!--
Thank you very much for putting in this PR!

PR is usually related with issue (github issue) or feature (slack, issue), please refer the link to issue and feature discussion. 
. If this PR is about tiny fix like spelling, document enhancement, please describe the fix in more details here. 

PR needs to reviewed before merged, please let the right people know.
Currently available team members to review and merge PR are:
- Qingfeng Xia
- Andrew Davis
- John Nonweiler

-->

Checklist
- [ ] Source is rebased on latest `upstream main` so is mergeable automatically or easily merged even with confliction.
- [ ] Title of this PR is meaningful: e.g. "fix issue #8 geomPipeline.py -o does not work", not "fix geomPipeline.py"
- [ ] Commit message is meaningful:  `git push origin +your_branch` to squash some tiny fixes for CI failures
- [ ] Give the maintainer the legal rights to change the open source license in the future (see wiki/Contribution.md) for details


