### PR TITLE
Fix various typos throughout the codebase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if(WIN32)
 endif()
 
 ##############################################################
-# PPP_DEV_MODE=ON is an env var defiend in $HOME/.profile, not .bashrc
+# PPP_DEV_MODE=ON is an env var defined in $HOME/.profile, not .bashrc
 # the developer can turn on more options on local PC
 ##############################################################
 set(PPP_DEV_MODE $ENV{PPP_DEV_MODE})
@@ -114,7 +114,7 @@ if(UNIX)
         set(CMAKE_BUILD_TYPE Debug)
         set(LCOV_EXCLUDES "build/*" "*/third-party/*" "/usr*")
         set (CMAKE_CXX_FLAGS "${COVERAGE_COMPILER_FLAGS} ${CMAKE_CXX_FLAGS}")
-        include("cMake/ppp_coverage_target.cmake")  # this cmake is project depedent, running scripts/run_all_test.sh in the build folder
+        include("cMake/ppp_coverage_target.cmake")  # this cmake is project dependent, running scripts/run_all_test.sh in the build folder
     endif()
 endif()
 
@@ -185,7 +185,7 @@ message("============= test preparation =================== \n"
 ######################## data for test ###########################
 if(WIN32)
     message(" symbolic link may not be supported on windows 10 before 2016 without admin previledge, xcopy instead \n")
-    # mklink is not recongized, so copy instead on Windows
+    # mklink is not recognized, so copy instead on Windows
     execute_process (
         #COMMAND cmd /c "IF  not EXIST \"${PROJECT_BINARY_DIR}\\data\" ( mklink /J  \"${PROJECT_BINARY_DIR}\\data\" \"${PROJECT_SOURCE_DIR}\\data\" )"
         COMMAND cmd /c " xcopy  \"${PROJECT_SOURCE_DIR}\\data\" \"${PROJECT_BINARY_DIR}\\data\" /c /l /v /e /k /y "
@@ -199,7 +199,7 @@ else()
 
 endif()
 
-######################## pyhton files and shell scripts for test ######################
+######################## python files and shell scripts for test ######################
 # # will override each time? yes
 # file(COPY ${PROJECT_SOURCE_DIR}/scripts/run_all_tests.sh 
 #     DESTINATION ${PROJECT_BINARY_DIR}

--- a/cMake/DetectOS.cmake
+++ b/cMake/DetectOS.cmake
@@ -55,7 +55,7 @@ if (UNIX)  # UNIX-like POSIX
         )
 
         # CMake execute_process() does not support pipe, so must use a shell
-        # not sure if all distro has the number version id,  "| sed 's/[.]0/./' " will remove zero afer dot
+        # not sure if all distro has the number version id,  "| sed 's/[.]0/./' " will remove zero after dot
         set(GET_OS_VERSION_CMD "bash -c \"awk '/VERSION_ID=/' /etc/*-release | sed 's/VERSION_ID=//' | sed 's/\"//' | sed 's/\"$//' ")
         execute_process(COMMAND  bash "-c"  "awk '/VERSION_ID=/' /etc/*-release | sed 's/VERSION_ID=//' | sed 's/\"//' | sed 's/\"$//'  "
           OUTPUT_VARIABLE CMAKE_OS_VERSION
@@ -77,9 +77,9 @@ if (UNIX)  # UNIX-like POSIX
     )
     if (DEBIAN_FOUND)
         set (CMAKE_OS_NAME "Debian" CACHE STRING "Operating system name" FORCE)
-        set (LINUX_PACKAGE_FORMAT "deb" CACHE STRING "linux distro native package formate rpm|deb" FORCE)
+        set (LINUX_PACKAGE_FORMAT "deb" CACHE STRING "linux distro native package format rpm|deb" FORCE)
     else(DEBIAN_FOUND)
-        set (LINUX_PACKAGE_FORMAT "rpm" CACHE STRING "linux distro native package formate rpm|deb" FORCE)
+        set (LINUX_PACKAGE_FORMAT "rpm" CACHE STRING "linux distro native package format rpm|deb" FORCE)
     endif (DEBIAN_FOUND)
 
 

--- a/cMake/ppp_package.cmake
+++ b/cMake/ppp_package.cmake
@@ -84,7 +84,7 @@ if(NOT PPP_SINGLE_PACKAGE)
     set(CPACK_COMPONENTS_ALL applications libraries headers python data)
     # all components in one package is the default behaviour
     # windows and macos may select component in the GUI installer wizard
-    # otherwise generate multple component packages on Linux
+    # otherwise generate multiple component packages on Linux
     set(CPACK_RPM_COMPONENT_INSTALL ON)
     set(CPACK_DEB_COMPONENT_INSTALL ON)
 

--- a/docker/Dockerfile_ssh
+++ b/docker/Dockerfile_ssh
@@ -58,7 +58,7 @@ RUN echo "%sudo    ALL=(ALL:ALL) ALL" >> /etc/sudoers
 ############### host key setup #################
 # https://nickjanetakis.com/blog/docker-tip-56-volume-mounting-ssh-keys-into-a-docker-container
 # copy the ssh key from host, so to fix the host public key when rebuilding the image
-# everytime install openssh-server, ssh key will be generated
+# every time install openssh-server, ssh key will be generated
 
 COPY .ssh /root/.ssh
 RUN  chmod 700 /root/.ssh && \

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -6,7 +6,7 @@ Note: this image is large, about 10 GB
 
 For evaluation of parallel-preprocessor, use the smaller image `ppp-centos` instead.
 
-OpenMC witth MPI is not supported in this docker image, consider using singularity image to support MPI parallelization on HPC platforms.
+OpenMC with MPI is not supported in this docker image, consider using singularity image to support MPI parallelization on HPC platforms.
 
 ### Get docker images
 
@@ -40,7 +40,7 @@ https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html
 
 ### 2. X11 forwarding on local Linux host machine  (deprecated as X11 via SSH is more convenient)
 
-to get an interative bash shell, as ubuntu 20.04
+to get an interactive bash shell, as ubuntu 20.04
 
 ```sh
 docker run -it --rm  -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$DISPLAY -h $HOSTNAME -v $HOME/.Xauthority:/home/jovyan/.Xauthority -v $PWD/:/workspace/  ppp_openmc  bash
@@ -103,7 +103,7 @@ see gull example in [build_openmc_mpi.sh](build_openmc_mpi.sh)
 
 ### MPI support for HPC cluster
 
-Singularity will bind host HOME into the image, so python package installed into normal user home's `.local` will not visiable.  One solution will be install all python module as root user into systemwide site-packages.
+Singularity will bind host HOME into the image, so python package installed into normal user home's `.local` will not visible.  One solution will be install all python module as root user into systemwide site-packages.
 
 
 MPI version can be selected during image building,  therefore to match with HPC cluster's MPI version.

--- a/docker/build_openmc_mpi.sh
+++ b/docker/build_openmc_mpi.sh
@@ -26,7 +26,7 @@ docker build . -f Dockerfile_ppp_openmc -t  qingfengxia/openmc_mpi   \
 
 ####################### to use this docker image ########################
 # if material not included, map the folder into the container, e.g. 
-#  give full path to materail data folder containing the xml
+#  give full path to material data folder containing the xml
 
 # export MAT_DIR=/mnt/windata/MyData/openmc_data/tendl-2019-hdf5/
 # docker run --rm -it -v $MAT_DIR:/mat_dir qingfengxia/ppp_openmc_mpi   bash

--- a/docker/build_ppp_openmc_mpi.sh
+++ b/docker/build_ppp_openmc_mpi.sh
@@ -29,7 +29,7 @@ docker build . -f Dockerfile_ppp_openmc -t  qingfengxia/ppp_openmc_mpi   \
 
 ####################### to use this docker image ########################
 # if material not included, map the folder into the container, e.g. 
-#  give full path to materail data folder containing the xml
+#  give full path to material data folder containing the xml
 
 # export MAT_DIR=/mnt/windata/MyData/openmc_data/tendl-2019-hdf5/
 # docker run --rm -it -v $MAT_DIR:/mat_dir qingfengxia/ppp_openmc_mpi   bash

--- a/scripts/site_generation.py
+++ b/scripts/site_generation.py
@@ -9,7 +9,7 @@ adapted from EERA: https://github.com/ScottishCovidResponse/Covid19_EERAModel/bl
 with hand-crafted: flawfinder, similarity, clang_tidy parsers
 
 All generated html file are located in repo_root/site/, 
-so all other resource path pathes should be relative to repo_root/site/
+so all other resource path paths should be relative to repo_root/site/
 
 Changelog: 
     - coverage_report_folder by default is located in `build` folder
@@ -28,7 +28,7 @@ import re
 import os.path
 
 my_project_name = "parallel-preprocessor"
-if os.path.exists("src"):  # CI mode. all pathes should be relative to repo_root/site/
+if os.path.exists("src"):  # CI mode. all paths should be relative to repo_root/site/
     coverage_report_folder = "../build/{}_coverage/index.html".format(my_project_name)
     doxygen_html_index = "../doxygen/html/index.html"
 else:  # local build test mode, run in build folder

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,7 +107,7 @@ if(PPP_USE_GEOM)
     add_subdirectory("Geom")
 endif()
 
-######### auto foramt check by cmake or git hook, or IDE ################
+######### auto format check by cmake or git hook, or IDE ################
 #find_package(ClangFormat)
 #if(NOT CLANG_FORMAT_FOUND)
 #    set(CLANG_FORMAT_BIN_NAME clang-format)

--- a/src/Geom/CollisionDetector.cpp
+++ b/src/Geom/CollisionDetector.cpp
@@ -673,7 +673,7 @@ namespace Geom
                 // VLOG_F(LOGLEVEL_DEBUG, "Item #%lu `%s` in NOT suppressed, although a floating shape ", i,
                 //       itemName(i).c_str());
             }
-            // todo: report to the operater but does not need response;
+            // todo: report to the operator but does not need response;
         }
         else if (row.size() == 1)
         {

--- a/src/Geom/CollisionDetector.h
+++ b/src/Geom/CollisionDetector.h
@@ -47,7 +47,7 @@ namespace Geom
     public:
         CollisionDetector()
         {
-            // The parent's default ctor be called automatically (implicitely)
+            // The parent's default ctor be called automatically (implicitly)
             myCharacteristics["coupled"] = true;
             myCharacteristics["indexPattern"] = IndexPattern::FilteredMatrix;
             myCharacteristics["indexDimension"] = 2;

--- a/src/Geom/Geom.cpp
+++ b/src/Geom/Geom.cpp
@@ -96,7 +96,7 @@ namespace Geom
 
         // 2. build the pipeline
 #if PPP_BUILD_TYPE
-        build(); // building pipeline from json configuraton file
+        build(); // building pipeline from json configuration file
 #else
         // this is example of hardcoded pipeline building
         myProcessors.push_back(std::make_shared<GeometryShapeChecker>());

--- a/src/Geom/GeomTests/GeomTests.cpp
+++ b/src/Geom/GeomTests/GeomTests.cpp
@@ -328,7 +328,7 @@ TEST_CASE("GeometryImprintTest")
         REQUIRE(countSubShapes(readback, TopAbs_COMPSOLID) == 1);
     }
 
-    /// boxes in 3D stacking configuraton
+    /// boxes in 3D stacking configuration
     SECTION("test_merge_stacked_cubes")
     {
         std::vector<TopoDS_Shape> shapes;

--- a/src/Geom/GeometryProcessor.h
+++ b/src/Geom/GeometryProcessor.h
@@ -37,7 +37,7 @@ namespace Geom
         {
             myCharacteristics["modified"] = false; // will not modify item() by this processor
             myCharacteristics["indexPattern"] = IndexPattern::Linear;
-            myCharacteristics["indexDimension"] = 1U; // indepent item processing, processing pair(i,j) for dim=2
+            myCharacteristics["indexDimension"] = 1U; // independent item processing, processing pair(i,j) for dim=2
             myCharacteristics["requiredProperties"] = {"mySolids", "myShapeType"}; // matching reader
         }
         virtual ~GeometryProcessor() = default;

--- a/src/Geom/GeometryPropertyBuilder.h
+++ b/src/Geom/GeometryPropertyBuilder.h
@@ -12,7 +12,7 @@ namespace Geom
 
     /// \ingroup Geom
     /**
-     * generate geometrical properties for meta data writting, for downstream processors
+     * generate geometrical properties for meta data writing, for downstream processors
      */
     class GeometryPropertyBuilder : public GeometryProcessor
     {
@@ -27,7 +27,7 @@ namespace Geom
     public:
         GeometryPropertyBuilder()
         {
-            // The parent's default ctor be called automatically (implicitely)
+            // The parent's default ctor be called automatically (implicitly)
             myCharacteristics["producedProperties"] = {"myGeometryProperties", "myGeometryUniqueIds"};
             // std::cout << myCharacteristics;
         }

--- a/src/Geom/GeometryReader.h
+++ b/src/Geom/GeometryReader.h
@@ -25,7 +25,7 @@ namespace Geom
      * + FreeCAD native format  *.FCStd
      * + parallel preproessor output: *.brep + *_metadata.json(*.metadata.json)
      * + manifest.json textual format: a list of filename-materail json objects
-     *     this json file must ended with "manifest.json", here is an exmaple:
+     *     this json file must ended with "manifest.json", here is an example:
      *    ```json
      *    [{
      *       "material": "one_material",
@@ -217,7 +217,7 @@ namespace Geom
                 if (solidCount) // debugging
                 {
                     const char* ns = p["name"].get<std::string>().c_str();
-                    LOG_F(INFO, "compound shape `%s` has %d compoents loaded ", ns, solidCount);
+                    LOG_F(INFO, "compound shape `%s` has %d components loaded ", ns, solidCount);
                 }
             }
         }
@@ -628,7 +628,7 @@ namespace Geom
                 {
                     std::string pname = "";
                     if (metadata.contains("filename"))
-                        pname = metadata["filename"]; // todo: component id, to give unqiue name
+                        pname = metadata["filename"]; // todo: component id, to give unique name
                     else if (metadata.contains("name"))
                         pname = metadata["name"];
                     else
@@ -752,7 +752,7 @@ namespace Geom
         {
             std::vector<ItemHashType> mySolidIDs;
             MapType<ItemHashType, ShapeErrorType> myShapeErrors;
-            for (auto const& item : mySolids) // what is the squence?
+            for (auto const& item : mySolids) // what is the sequence?
             {
                 mySolidIDs.push_back(item.first); // the sequence
                 myShapeErrors[item.first] = ShapeErrorType::NoError;

--- a/src/Geom/GeometrySearchBuilder.h
+++ b/src/Geom/GeometrySearchBuilder.h
@@ -27,8 +27,8 @@ namespace Geom
                                                   });
     enum class ShapeSimilarity
     {
-        Unknown,   ///!< not calculated/intialized, or has error during similarity matching
-        Identical, ///!< idential shapes
+        Unknown,   ///!< not calculated/initialized, or has error during similarity matching
+        Identical, ///!< identical shapes
         Similar,   ///!< need some criteria to define similarity, volume, topology
         Insimilar, ///!< all the rest, not identical, not similar
     };

--- a/src/Geom/GeometryShapeChecker.h
+++ b/src/Geom/GeometryShapeChecker.h
@@ -306,7 +306,7 @@ namespace Geom
             bool rebuildFaceMode = true;
             bool mergeVertexMode = true; // leader to `BOPAlgo_IncompatibilityOfEdge`
             bool mergeEdgeMode = true;
-            bool curveOnSurfaceMode = false; // BOPAlgo_InvalidCurveOnSurface: tolerance compatability check
+            bool curveOnSurfaceMode = false; // BOPAlgo_InvalidCurveOnSurface: tolerance compatibility check
 
             // FreeCAD develper's note: I don't why we need to make a copy, but it doesn't work without it.
             /// maybe, mergeVertexMode() will modify the shape to check

--- a/src/Geom/GeometryTypes.h
+++ b/src/Geom/GeometryTypes.h
@@ -201,7 +201,7 @@ namespace Geom
         j = p.name; // tmp change the output to single string type
     }
 
-    /// must be defiend in the same namespace as Material class
+    /// must be defined in the same namespace as Material class
     inline void from_json(const json& j, Material& p)
     {
         if (j.contains("name"))

--- a/src/Geom/OccUtils.cpp
+++ b/src/Geom/OccUtils.cpp
@@ -90,7 +90,7 @@ namespace Geom
             }
             else
             {
-                LOG_F(ERROR, "file exension is not supported for %s", file_name.c_str());
+                LOG_F(ERROR, "file extension is not supported for %s", file_name.c_str());
             }
         }
 
@@ -811,7 +811,7 @@ namespace Geom
             const Standard_Integer aStatus = aMesher->GetStatusFlags();
             if (aStatus)
             {
-                // LOG_F(ERROR, "failed to mesh the shape, retrun the shared_ptr to a false value");
+                // LOG_F(ERROR, "failed to mesh the shape, return the shared_ptr to a false value");
                 aMesher.reset(); // set to nullptr
             }
             return aMesher;

--- a/src/Geom/OccUtils.h
+++ b/src/Geom/OccUtils.h
@@ -56,7 +56,7 @@ namespace Geom
         /// based on axis-aligned boundbox matching and surface area equivalence
         GeomExport Standard_Boolean isCoincidentDomain(const TopoDS_Shape& shape, const TopoDS_Shape& shape2);
 
-        /// two-step unifying: first unify edges, seconly unify faces,
+        /// two-step unifying: first unify edges, secondly unify faces,
         /// deprecated: use glueFaces() instead
         GeomExport TopoDS_Shape unifyFaces(const TopoDS_Shape& _shape);
 

--- a/src/Geom/OpenCascadeAll.h
+++ b/src/Geom/OpenCascadeAll.h
@@ -457,7 +457,7 @@
 //
 #include <APIHeaderSection_MakeHeader.hxx>
 
-// IGES format suport
+// IGES format support
 #include <IGESCAFControl_Reader.hxx>
 #include <IGESControl_Controller.hxx>
 #include <IGESControl_Reader.hxx>
@@ -486,7 +486,7 @@
 
 #include <Transfer_FinderProcess.hxx>
 #include <Transfer_TransientProcess.hxx>
-// save to bindary foramt
+// save to bindary format
 #include <BinTools.hxx>
 #include <BinTools_ShapeSet.hxx>
 

--- a/src/PPP/CMakeLists.txt
+++ b/src/PPP/CMakeLists.txt
@@ -109,7 +109,7 @@ if(PPP_USE_MPI)
         #add_definitions(-DPPP_BUILD_MPI=1)
         include_directories(${MPI_CXX_INCLUDE_DIRS})
         link_directories(${MPI_CXX_LIBRARY_DIRS})
-        link_libraries(${MPI_CXX_LIBRARIES})  # full pathes for shared libraries
+        link_libraries(${MPI_CXX_LIBRARIES})  # full paths for shared libraries
     endif()
 endif()
 

--- a/src/PPP/CommandLineProcessor.h
+++ b/src/PPP/CommandLineProcessor.h
@@ -51,7 +51,7 @@ namespace PPP
      * this approach is not efficient for the cost of launch new process, but flexible and powerful
      * e.g. you can write processor in any language for pipeline working.
      *
-     * File IO is another constraint, so shared memery and pipe(string stream),
+     * File IO is another constraint, so shared memory and pipe(string stream),
      * assuming the external program get input from stream and output to stream like
      * `echo input|myprog > output`
      *

--- a/src/PPP/CouplingMatrixBuilder.h
+++ b/src/PPP/CouplingMatrixBuilder.h
@@ -10,7 +10,7 @@ namespace PPP
      * \brief  detect item pair coupling in the target expensive processor and build a coupling matrix
      *
      * the coupling matrix is more general than Geometry's adjacency matrix.
-     * this processor can be used to detect/fileter potential coupling and skip item pair definitely not in
+     * this processor can be used to detect/filter potential coupling and skip item pair definitely not in
      * coupling. parallel accessor need this information to coordinate coupling operation in parallel
      *
      */
@@ -19,7 +19,7 @@ namespace PPP
         TYPESYSTEM_HEADER();
 
     private:
-        /// declare your new data proeprties here
+        /// declare your new data properties here
         SparseMatrix<bool> myCouplingMatrix;
 
         std::shared_ptr<Processor> myTargetProcessor;
@@ -64,7 +64,7 @@ namespace PPP
          */
         virtual void prepareOutput() override final
         {
-            // todo: if called in pipeline explicitly, replace the filename the defiend in Config
+            // todo: if called in pipeline explicitly, replace the filename the defined in Config
             // myCouplingMatrix.writeMatrixMarketFile("couplingMatrix.mm");
             myOutputData->emplace("myCouplingMatrix", std::move(myCouplingMatrix));
         }

--- a/src/PPP/Executor.h
+++ b/src/PPP/Executor.h
@@ -41,7 +41,7 @@ namespace PPP
             return myWorkerCount;
         }
 
-        /// need wait() complete until processs the next item
+        /// need wait() complete until process the next item
         inline bool synchronous() const
         {
             return isSynchronous;

--- a/src/PPP/OperatorProxy.h
+++ b/src/PPP/OperatorProxy.h
@@ -11,8 +11,8 @@ namespace PPP
     /// \ingroup PPP
     /**  Proxy class for Operator, implements AbstractOperator and behaves like a operator
      *
-     * Processor will interact with only with this ProxyOperator, which forwards to multiple concrete operator
-     * ConsoleOperator is the default operator, it will print json data without actuall caring the content,
+     * Processor will interact only with this ProxyOperator, which forwards to multiple concrete operator
+     * ConsoleOperator is the default operator, it will print json data without actually caring about the content,
      * while each module should implement Graphic and Web Operator to view result and confirm user choice.
      * see wiki on user interface design section
      */

--- a/src/PPP/ParallelAccessor.h
+++ b/src/PPP/ParallelAccessor.h
@@ -47,10 +47,10 @@ namespace PPP
     /**
      * ParallelAccessor implement a lock free parallel operation (write/modification),
      * on a multi-dimensional data structure, e.g. sparse matrix, when items are coupled together.
-     * Currently, it supports binary operaton within a 2D data structure, e.g. matrix, with mutual exclusion;
+     * Currently, it supports binary operation within a 2D data structure, e.g. matrix, with mutual exclusion;
      * triple operation involving 3 items in coupling is too complicated yet implemented.
      *
-     * This ParallelAccess class implements the synchronous mode, while the dervied class AsynchronousDispatcher
+     * This ParallelAccess class implements the synchronous mode, while the derived class AsynchronousDispatcher
      * implements asynchronous mode which is more efficient.
      * For the synchronous mode, the scheduler wait for all workers complete and schedule new task for all workers,
      * As only the schedular can allocate task (modify  `myRemainedItems`), there is no need for mutex.
@@ -58,7 +58,7 @@ namespace PPP
      * @param Filter: function of type `bool function(i, j)` to validate if item i and j are connected/coupled/adjacent
      * @param itemCount: the problem scale (total item number to processed)
      * @param blockCount: process blockCount operations in one batch for each thread call.
-     * @param accessorCount: number of accessors (thread count in multi-thread executation mode) in parallel
+     * @param accessorCount: number of accessors (thread count in multi-thread execution mode) in parallel
      *
      */
     class ParallelAccessor : Accessor<std::vector<ItemIndexType>>

--- a/src/PPP/PipelineController.cpp
+++ b/src/PPP/PipelineController.cpp
@@ -219,7 +219,7 @@ namespace PPP
             std::string outfile = Context::dataStorage().getFullPath("processed_info.json");
             std::fstream report_info(outfile);
 
-            // processsed data writing, writer is not always needed
+            // processed data writing, writer is not always needed
             bool hasWriter = !myConfig["writers"].empty();
             if (hasWriter)
             {
@@ -255,7 +255,7 @@ namespace PPP
 
         // 2. build the pipeline
 #if PPP_BUILD_TYPE
-        build(); // building pipeline from json configuraton file
+        build(); // building pipeline from json configuration file
 #else
 // this is example of hardcoded pipeline building
 #if PPP_USE_BOOST_PROCESS

--- a/src/PPP/Processor.h
+++ b/src/PPP/Processor.h
@@ -28,7 +28,7 @@ namespace PPP
     /**
      * \brief base class for all processors, mappable to vtkAlgorithm,  opKernel of tensorflow
      * see API of vtkAlgorithm: <https://vtk.org/doc/nightly/html/classvtkAlgorithm.html>
-     * Multiple input and multiple ouput, is not supported, GetNumberOfInputPorts()
+     * Multiple input and multiple output, is not supported, GetNumberOfInputPorts()
      * register input parameters, given the doc and default values by the processor developer
      * register generated data properties (downstream processors may depend on)
      * register required properties
@@ -69,7 +69,7 @@ namespace PPP
         {
             return myResult;
         }
-        /// configration (controlling parameters) input
+        /// configuration (controlling parameters) input
         inline void setConfig(const Config& config)
         {
             myConfig = config;
@@ -124,7 +124,7 @@ namespace PPP
         /// @}
 
         /// @{ API for pipe controller
-        /// default imp: reserve memery for item report vector
+        /// default imp: reserve memory for item report vector
         virtual void prepareInput()
         {
             myItemReports.resize(myInputData->itemCount());
@@ -176,7 +176,7 @@ namespace PPP
         /// @{ result group
 
         /**
-         * report after successfully processsing all items, according to verbosity level
+         * report after successfully processing all items, according to verbosity level
          * write/append into output Information, may also report to operator interface
          */
         virtual void report()
@@ -239,7 +239,7 @@ namespace PPP
         }
 
         /**
-         * checkpoint and dump data property, configration, and information
+         * checkpoint and dump data property, configuration, and information
          * useful for debugging when there is an error, or interrupted by Ctrl-C signal
          * this should be done by pipeline's signal handler
          */
@@ -412,7 +412,7 @@ namespace PPP
             {
                 LOG_F(ERROR,
                       "parameter `%s` is not found in config\n"
-                      "try the overloded version with default value instead",
+                      "try the overloaded version with default value instead",
                       name.c_str());
                 throw ProcessorError("parameter is not found in processor configuration");
             }
@@ -431,7 +431,7 @@ namespace PPP
             {
                 LOG_F(ERROR,
                       "parameter `%s` is not found in config\n"
-                      "try the overloded version with default value instead",
+                      "try the overloaded version with default value instead",
                       name.c_str());
                 throw ProcessorError("parameter is not found in processor configuration");
             }
@@ -506,7 +506,7 @@ namespace PPP
                 else
                 {
 #ifdef WIN32
-                    // start /B  will start an app/cmd in backgroud, without /B option, a new console windows will show
+                    // start /B  will start an app/cmd in background, without /B option, a new console windows will show
                     std::string cmd = "start /B python " + py_monitor_path.string() + " " + log_filename + " " + title;
 #else
                     // On Posix OS by appending `&`, then the command is nonblocking /detached from the main process
@@ -522,12 +522,12 @@ namespace PPP
         }
 
     protected:
-        /// intrinsic attribute of the process operation, parallel without affact other item? readonly?
+        /// intrinsic attribute of the process operation, parallel without effecting other item? readonly?
         /// set myCharacteristics in constructor may make ctor is not default
         Config myCharacteristics;
         Config myConfig; /// treated as value type
 
-        /// chained up intput -> output, can be saved to file,each processor appends to myInfo
+        /// chained up input -> output, can be saved to file,each processor appends to myInfo
         std::shared_ptr<Information> myInfo;
         std::shared_ptr<ProcessorResult> myResult;
         VectorType<std::shared_ptr<std::stringstream>> myItemReports;

--- a/src/PPP/ProcessorError.h
+++ b/src/PPP/ProcessorError.h
@@ -35,7 +35,7 @@ namespace PPP
 
         /** Returns a pointer to the (constant) error description.
          *  @return A pointer to a const char*. The underlying memory
-         *          is in posession of the Exception object. Callers must
+         *          is in possession of the Exception object. Callers must
          *          not attempt to free the memory.
          */
         virtual const char* what() const throw() override

--- a/src/PPP/ProcessorTemplate.h
+++ b/src/PPP/ProcessorTemplate.h
@@ -8,7 +8,7 @@ namespace PPP
     /// \ingroup PPP
     /**
      * \brief template + lambda to build a new processor inplace without declare a new processor type.
-     *  this class will not be wrapped for Python, only used in C++, see exmaple in ParallelAccessorTest.cpp
+     *  this class will not be wrapped for Python, only used in C++, see example in ParallelAccessorTest.cpp
      * `myResultData` is the place to save result data
      *
      * @param ProcessorType a concrete process class it inherits from, in order to share data

--- a/src/PPP/SparseMatrix.cpp
+++ b/src/PPP/SparseMatrix.cpp
@@ -23,7 +23,7 @@ namespace PPP
         }
         if (mm_is_complex(matcode) && mm_is_matrix(matcode) && mm_is_sparse(matcode))
         {
-            cout << "Market Market type: " << mm_typecode_to_str(matcode) << ", is not supproted\n";
+            cout << "Market Market type: " << mm_typecode_to_str(matcode) << ", is not supported\n";
         }
 
         /* find out size of sparse matrix .... */

--- a/src/PPP/SparseMatrix.h
+++ b/src/PPP/SparseMatrix.h
@@ -19,7 +19,7 @@ namespace PPP
 {
 
     /// \ingroup PPP
-    /** lock-free parallel sparse matrix data structrue
+    /** lock-free parallel sparse matrix data structure
      * consider: VectorType<std::shared_ptr<std::unordered_map<ItemIndexType, T>>>
      * */
     template <typename T> class SparseMatrix
@@ -191,7 +191,7 @@ namespace PPP
             }
             if (mm_is_complex(matcode) && mm_is_matrix(matcode) && mm_is_sparse(matcode))
             {
-                cout << "Market Market type: " << mm_typecode_to_str(matcode) << ", is not supproted\n";
+                cout << "Market Market type: " << mm_typecode_to_str(matcode) << ", is not supported\n";
             }
 
             /* find out size of sparse matrix .... */

--- a/src/PPP/ThreadPoolExecutor.h
+++ b/src/PPP/ThreadPoolExecutor.h
@@ -120,7 +120,7 @@ namespace PPP
                 // as the coupling-test is a cheap op, multi-threading may not be worth of doing.
                 // if it is really needed, then build the CouplingMatrixBuilder into the pipeline
                 // ThreadPoolExecutor te(b, myWorkerCount, myThreadPool);
-                // te.process();  // this will move/emptry the couplingMatrix()
+                // te.process();  // this will move/empty the couplingMatrix()
 
                 // note: preparaOutput is not called, if called, "myCouplingMatrix" will be inserted into data
                 auto cmat = b->couplingMatrix();
@@ -135,7 +135,7 @@ namespace PPP
         {
             // decide on the processor's IndexPattern
             // for dense matrix, an linear pattern, split into equally spaced row groups
-            // for Triangle, 2D tranverse, AsynchronousDispatcher is the best choice no matter of coupling
+            // for Triangle, 2D traverse, AsynchronousDispatcher is the best choice no matter of coupling
             size_t itemPerThread = size_t(NItems / myWorkerCount);
 
             // in case: itemPerThread  = 0 when Nitems < myWorkerCount

--- a/src/PPP/TypeDefs.h
+++ b/src/PPP/TypeDefs.h
@@ -44,8 +44,8 @@ namespace PPP
     enum class DevicePreference
     {
         CPU,  ///< item count is small, but processing each item take time and complext to push to GPU
-        GPU,  ///< GPU acceleraton, suitable for large item-count but simple calculation
-        FPGA, ///< good for realtime data processing, by hardware parallization
+        GPU,  ///< GPU acceleration, suitable for large item-count but simple calculation
+        FPGA, ///< good for realtime data processing, by hardware parallelization
     };
 
     NLOHMANN_JSON_SERIALIZE_ENUM(DevicePreference, {
@@ -93,7 +93,7 @@ namespace PPP
         Linear,            ///< each item has the same computation time, sliced into block, not coupled
         FilteredVector,    ///< not each item will be ProcessItem(), executor check "required()"
         PartitionIdVector, ///< item has an partition Id == threadID to bind with a specific thread
-        /// 2 operands operation not coupled operaton
+        /// 2 operands operation not coupled operation
         UpperTriangle, ///< for itemPair,  op(i, j) for i<j, skip diagonal op(i,i)
         LowerTriangle, ///< not in use, as executor use UpperTriangle by default
         DenseMatrix,   ///< 2D traverse, both op(i, j), op(j, i)

--- a/src/PPP/UniqueId.h
+++ b/src/PPP/UniqueId.h
@@ -57,7 +57,7 @@ namespace PPP
 
         /**
          * because half precision's max number is about 65000 (with 32 as EPS)
-         * CAD ususally use mm as length unit, so volume would overflow for half precision if volume is
+         * CAD usually use mm as length unit, so volume would overflow for half precision if volume is
          * scale to deci-meter, or metre, kilometer, depends on geometry size
          * */
 
@@ -150,7 +150,7 @@ namespace PPP
         }
 
         /// used by GeometryPropertyBuilder class in parallel-preprocessor
-        /// assuming native endianess, always calculate Id using the same endianness
+        /// assuming native endianness, always calculate Id using the same endianness
         /// this should generate unique Id for a vector of 4 double values
         /// this is not universal unique Id (UUID) yet, usurally std::byte[16]
         UniqueIdType uniqueId(const std::vector<double> values)

--- a/src/PPP/Utilities.cpp
+++ b/src/PPP/Utilities.cpp
@@ -24,7 +24,7 @@ namespace PPP
             if (i != std::string::npos)
             {
                 auto extension = filepath.substr(i + 1, filepath.length() - i);
-                // std::cout << "file extention extracted: " << extension << std::endl;
+                // std::cout << "file extension extracted: " << extension << std::endl;
                 if (extension.length() && extension.length() == ext.length())
                 {
                     for (size_t j = 0; j < extension.length(); j++)
@@ -66,10 +66,10 @@ namespace PPP
             return true;
         }
 
-        /// user must make sure data can be implicitely converted into json object
+        /// user must make sure data can be implicitly converted into json object
         template <class T> bool toJson(const T& data, const std::string& filename)
         {
-            json jObj = data; // implicitely converted into json object
+            json jObj = data; // implicitly converted into json object
             std::ofstream of(filename, std::ios::out | std::ios::binary);
             std::vector<std::uint8_t> v_buffer;
             if (hasFileExt(filename, "json"))

--- a/src/PPP/Utilities.h
+++ b/src/PPP/Utilities.h
@@ -36,7 +36,7 @@ namespace PPP
         /// read all lines a text file into the output vector (the second parameter)
         bool AppExport getFileContent(const std::string fileName, std::vector<std::string>& vecOfStrs);
 
-        /// user must make sure data can be implicitely converted into json object
+        /// user must make sure data can be implicitly converted into json object
         template <class T> bool toJson(const T& data, const std::string& filename);
 
         /// todo: uniqueness is not guatanteed, the return type is size_t as std::hash

--- a/src/PPP/WorkflowController.h
+++ b/src/PPP/WorkflowController.h
@@ -7,7 +7,7 @@ namespace PPP
     /// dataflow topology type for workflow
     enum TopologyType
     {
-        Unknown = 0,  ///< default value, unkown, unspecified
+        Unknown = 0,  ///< default value, unknown, unspecified
         Pipeline = 1, ///< single data source, single output pipeline, no fork
         Tree = 2,     ///< single data source, multiple pipelines/forks/outputs
         Graph = 3     ///< Directed acyclic graph, most complicate

--- a/src/PropertyContainer/Property.h
+++ b/src/PropertyContainer/Property.h
@@ -83,7 +83,7 @@ namespace PPP
 
     /**
       a data class contains data of any type, with control flag,
-      this class is used by PropertyContainer dervied class only
+      this class is used by PropertyContainer derived class only
       todo: serialization is not yet supported, static Property::TypeRegistry, to register the serializer can be a
       choice This class should be `is_standard_layout<> = true`, i.e. POD (compatible with C struct)
     */
@@ -124,7 +124,7 @@ namespace PPP
                 , data(_any)
                 , type("")
                 , flag(PropertyFlag::None){
-                      // todo: try to demangle the readeable type name
+                      // todo: try to demangle the readable type name
                       // std::cout << name << " Property user ctor\n";
                   };
 

--- a/src/PropertyContainer/PropertyContainer.hpp
+++ b/src/PropertyContainer/PropertyContainer.hpp
@@ -63,7 +63,7 @@ namespace PPP
 
     /// \ingroup PPP
     /**
-     * dynamic heterogenous container to simulate dynamic property, based on std::any
+     * dynamic heterogeneous container to simulate dynamic property, based on std::any
      *
      * APIs  are compatible with STL associative container with STL iterator, but
      * those APIs protected because Property type is only accessible by derived class
@@ -164,7 +164,7 @@ namespace PPP
         template <typename T, typename = std::enable_if<std::is_const<T>::value>>
         default_pointer_type<T> get(const std::string& key) const
         {
-            std::cout << "DEBUG info: const versoin of get<const AType>() is called!" << std::endl;
+            std::cout << "DEBUG info: const version of get<const AType>() is called!" << std::endl;
             if (contains(key))
             {
                 return any_cast<default_pointer_type<T>>(myProperties.at(key).data);
@@ -179,7 +179,7 @@ namespace PPP
          * */
         template <typename T> T getValue(const std::string& key) const
         {
-            std::cout << "DEBUG info: const versoin of get<const AType>() is called!" << std::endl;
+            std::cout << "DEBUG info: const version of get<const AType>() is called!" << std::endl;
             if (contains(key))
             {
                 auto ptr = any_cast<default_pointer_type<const T>>(myProperties.at(key).data);

--- a/src/PropertyContainer/PropertyContainerTest.cpp
+++ b/src/PropertyContainer/PropertyContainerTest.cpp
@@ -116,7 +116,7 @@ TEST_CASE_METHOD(PropertyContainerTest, "add and remove a STL container as a pro
     b->push_back(1);
     auto bb = d.get<B>("B"); // second template parameter is default to `std::shared_ptr<A>`
     // std::cout<< "size of the modified std container is: " << bb->size() <<"\n";
-    // const char* MY_MSG = "modified size of the modified stl container is NOT sync with the property Containter";
+    // const char* MY_MSG = "modified size of the modified stl container is NOT sync with the property Container";
     REQUIRE(bb->size() == length + 1U);
     d.erase("B"); // no effect if no such key
 }

--- a/src/PropertyContainer/Readme.md
+++ b/src/PropertyContainer/Readme.md
@@ -17,7 +17,7 @@ This property container is not thread-safe, because STL container `std::map` is 
 
 ### json serialization
 
-json for basic types (as already supproted by nlohmann json library) are supported out of box with default json serialization,  more user types might be supported by ADL. User serializer and deserializer can be specified when `setSerializable(key, value, serializer_function)`.
+json for basic types (as already supported by nlohmann json library) are supported out of box with default json serialization,  more user types might be supported by ADL. User serializer and deserializer can be specified when `setSerializable(key, value, serializer_function)`.
 
 Note: this feature is under design, yet fully tested.  Also consider save data into the `DataStorage` class. 
 

--- a/src/python/AppPy.cpp
+++ b/src/python/AppPy.cpp
@@ -13,7 +13,7 @@ namespace py = pybind11;
 PYBIND11_MODULE(ppp, m)
 {
     m.doc() = R"pbdoc(
-        Pybind11 wrapper of the parallel preprocesor
+        Pybind11 wrapper of the parallel preprocessor
         -----------------------
         .. currentmodule:: cmake_example
         .. autosummary::

--- a/src/python/analyzeProcessedResult.py
+++ b/src/python/analyzeProcessedResult.py
@@ -70,7 +70,7 @@ def metadata_stat(file_name):
             if p["suppressed"]:
                 nb_suppressed += 1
         nb_record = len(d)
-        print(f"{nb_suppressed} suppresed out of metadata record number {nb_record}")
+        print(f"{nb_suppressed} suppressed out of metadata record number {nb_record}")
 
 
 total_op = 0

--- a/src/python/detectFreeCAD.py
+++ b/src/python/detectFreeCAD.py
@@ -124,7 +124,7 @@ def get_freecad_lib_path():
 
 def get_lib_path_on_windows(fc_name):
     # windows installer has the options add freecad to PYTHONPATH
-    # this can also been done manually afterward, settting env variable PYTHONPATH
+    # this can also been done manually afterward, setting env variable PYTHONPATH
     # the code below assuming freecad is on command line search path
 
     if fc_name:

--- a/src/python/pppMonitorProgress.py
+++ b/src/python/pppMonitorProgress.py
@@ -5,8 +5,8 @@
 parse local log file or message via networking url,  plot the progress dialog
 The percentage format is defaulted as  r" ([0-9,.]+) percent", but can be provided as the third argument.
 
-For local file, using QTimer to poll  the log file change, pygtail module from PyPI can be a choise
-For network url liek websocket, using Qt event loop  (not yet implemented)
+For local file, using QTimer to poll  the log file change, pygtail module from PyPI can be a choice
+For network url like websocket, using Qt event loop  (not yet implemented)
 This script has been tested to work with PyQt5 on Windows and PySide2 on Linux
 """
 USAGE = "pppMonitorProgress.py log_file  [window_title]  [percentage_regex_pattern]"

--- a/src/python/pppPipelineController.py
+++ b/src/python/pppPipelineController.py
@@ -6,7 +6,7 @@
 
 """
 This script defines utility functions that can be shared by all pipeline controllers such as GeomPipeline.py.
-By using those functions,  consistent command line argument and config.json header can be achived.
+By using those functions,  consistent command line argument and config.json header can be achieved.
 
 At the end of this script. a demonstration of usage of PPP core module, using CommandLineProcessor.
 ParallelAccessorTest.cpp is a demo (test) of instantiation of ProcessorTemplate class in C++
@@ -197,7 +197,7 @@ def generate_config_file(config_file_content, args):
 
     config_file_given = False
     generated_config_file_name = "config.json"
-    # input json file is config, but not geomtry input manifest file
+    # input json file is config, but not geometry input manifest file
     if args.input.find(".json") > 0:
         with open(args.input, "r") as f:
             _json_file_content = json.loads(f.read())

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -22,7 +22,7 @@ while it is not quite pythonic way.
 
 
 This setup must be run after C++ shared libraries have been compiled by cmake.
-c++ runtime *.so/dll must be installed to somwhere loadable (appending LD_LIBRARY_PATH if installed to non-system path)
+c++ runtime *.so/dll must be installed to somewhere loadable (appending LD_LIBRARY_PATH if installed to non-system path)
 either by conda or platform installer like deb.rpm/make install
 
 ### PyPI upload is yet done
@@ -32,7 +32,7 @@ python3 setup.py bdist_wheel
 rm package.egg-info #  rm folder where the sources.txt(manifest) will not be updated
 python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 # for CI, just copy to asset folder
-# copy the output package from ./dist to somwhere? to be downloaded, should be done by CI script
+# copy the output package from ./dist to somewhere? to be downloaded, should be done by CI script
 ```
 
 see a full list of setup.py arguments
@@ -146,7 +146,7 @@ kwargs = {
     "name": "parallel-preprocessor",
     "version": "0.3.0",  # todo: get the version info from file written by cmake
     #"packages": ["ppp"],  # find source code folder with __init__.py, find_packages()
-    # ext_modules # cpp soruce to build, skip it as cmake will build
+    # ext_modules # cpp source to build, skip it as cmake will build
     # "license": "TBD",
     "author": "qingfeng xia",
     "author_email": "qingfeng xia@UKAEA",

--- a/src/python/test_collision.py
+++ b/src/python/test_collision.py
@@ -111,12 +111,12 @@ class StrongInterferenceTest(GeomTestBase):
         doc.recompute()
         return objs
 
-    def validate_geometry(self, shape, supressing=True):
+    def validate_geometry(self, shape, suppressing=True):
         print("len(shape.Faces)", len(shape.Faces))
         print("len(shape.Solids) = ", len(shape.Solids))
         assert shape.ShapeType == "CompSolid" or shape.ShapeType == "Compound"
         # depends on implementation on Cpp side
-        if supressing:
+        if suppressing:
             assert len(shape.Solids) == 4
             assert len(shape.Faces) == 20  # 4 cubes shares 4 faces, total 20 faces
         else:

--- a/wiki/ArchitectureDesign.md
+++ b/wiki/ArchitectureDesign.md
@@ -27,7 +27,7 @@ All selected components must be cross-platform. In this early development stage,
   - FreeCAD/BREP
 
 + UTF8 encoding is assumed and stored in `std::string`
-  Note: 1. this may work for MasOS and Linux of utf8 locale; 
+  Note: 1. this may work for macos and Linux of utf8 locale; 
         2. `filesystem::path::string()` not `filesystem::path::u8string()`
 
 ### Modular design
@@ -36,13 +36,13 @@ Folder structure corresponds to modular design, inspired by FreeCAD project.
 see [CodeStructure.md](./CodeStructure.md) for description for each header file.
 
 + third-party/Base: type system and BaseClass for c++ (extracted from FreeCAD project)
-+ PropertyContainer: heterogenous container based on `std::any`, may be replaced with FreeCAD's in the future
++ PropertyContainer: heterogeneous container based on `std::any`, may be replaced with FreeCAD's in the future
 + PPP: framework infrastructure for parallel preprocessing, depends only on STL and some header-only third-party libraries.
 + Geom: geometry processing relies on OCCT, including 2D surface meshing (facetizing)
 + Mesh: 3D volume meshing (planned yet coded)
 + third-party: json, catch2, loguru, SGeom, etc
 + test: unit test
-+ python: python wrapping and python script exectuables
++ python: python wrapping and python script executables
 + scripts: utility script
 + data: testing data
 

--- a/wiki/BuildOnConda.md
+++ b/wiki/BuildOnConda.md
@@ -28,7 +28,7 @@ The build scripts `build.sh` (for Unix-like OS) and `bld.bat` (windows batch fil
 
 To build conda package, first of all, install anaconda python3 and install necessary packages like `conda-build`, and run the command in the `recipe` folder of this repository: `conda build meta.ymal`
 
-The conda build task is conducted a seperate virtual environment automatically, so is the test(run) process.  
+The conda build task is conducted a separate virtual environment automatically, so is the test(run) process.  
 `D:\Software\anaconda3\envs\cf\conda-bld\ppp_1597347412425`
 On windows, cmake isntalled to the `base` conda environment can still detect `occt` package installed in the conda-build tmp conda environment.
 

--- a/wiki/BuildOnLinux.md
+++ b/wiki/BuildOnLinux.md
@@ -120,7 +120,7 @@ yum install opencascade-draw, opencascade-foundation,  opencascade-modeling,  op
 
 ### For OSs without OCCT packages, compile OpenCASCADE 7.x from source
 
-For centos7 and centos7, the Dockerfile has updated unix shell commmand to install compiler toolchain.
+For centos7 and centos7, the Dockerfile has updated unix shell command to install compiler toolchain.
 
 Download the opencascade source code and compile from source, Compile opencascade if not available in package repository, e.g. centos 7/8,  see the "Dockerfile_centos" file for updated instructions.
 
@@ -220,7 +220,7 @@ or `sudo dpkg -i parallel-preprocessor*` on debian/ubuntu
 
 Without installation, this software can be evaluated by running [geomPipeline.py path_to_geometry_file](./python/geomPipeline.py), after building from source.
 
-Note: change directory to the folder containing geomPipeline.py is not necessary, if user has put full path of `parallel-preprocessor/build/bin/` folder into user path. For example, by editing PATH varialbe in `~/.bashrc` on Ubuntu, it will just work as installed program.
+Note: change directory to the folder containing geomPipeline.py is not necessary, if user has put full path of `parallel-preprocessor/build/bin/` folder into user path. For example, by editing PATH variable in `~/.bashrc` on Ubuntu, it will just work as installed program.
 
 Just append the `bin` folder to user `path` in `~/.bashrc`, that is all.  you should be able to imprint geometry by `geomPipeline.py  input_geometry_path`.   And also append `build/lib` to `LD_LIBRARY_PATH`
 

--- a/wiki/BuildOnMacOS.md
+++ b/wiki/BuildOnMacOS.md
@@ -13,7 +13,7 @@ Homebrow is the missing package manager for MacOS, and it make software installa
 
 ### Install Dependencies ( Mac OS X )
 
-Install some developer tools for QA and documenatation generation
+Install some developer tools for QA and documentation generation
 `brew update && brew install  cppcheck lcov poppler htmldoc graphviz doxygen`
 
 Install third-party libraries that Parallel-Preprocessor relies on:

--- a/wiki/BuildOnWindows.md
+++ b/wiki/BuildOnWindows.md
@@ -45,7 +45,7 @@ if CASROOT env var has been set, this step maybe skip for cmake building
 `git` can be installed from "Git for Windows" installer. 
 
 `boost`, can be installed by conda
-`pybind11` can be installed by conda, alternatively `pybind11` can be downloaded (git clone) from github during cmake build processs
+`pybind11` can be installed by conda, alternatively `pybind11` can be downloaded (git clone) from github during cmake build process
 
 There are 3 ways to install OpenCASACDE.  TBB is a dependent for occt package on conda-forge and bundled with official OpenCASACDE release
 
@@ -81,7 +81,7 @@ Apparently, conda is the better way to compile and run "Parallel Preprocessor".
 
 ### Method 2: Install official OpenCASCADE 7.4
 
-It is compiled with visual studio C++ 2017. Customed installation, install only source code (we need header files) and binary files,  is sufficiennt  about 1GB.
+It is compiled with visual studio C++ 2017. Customed installation, install only source code (we need header files) and binary files,  is sufficient  about 1GB.
 validate the installation by run sample app.  `Inspector.exe`
 
 As suggested in define OpenCASCADE official document, define the env var `CASROOT`, to the folder you can find `env.bat`
@@ -109,7 +109,7 @@ One potential way to compile ppp is to use the header and dll files from FreeCAD
 <https://wiki.freecadweb.org/Compile_on_Windows>
 
 During installation, set the ppp installation path the same as FreeCAD installation path `D:\Software\FreeCAD0.18`,
-all dll goes into `D:\Software\FreeCAD0.18\bin` and all python sripts installed to FreeCAD's python's site-packages. 
+all dll goes into `D:\Software\FreeCAD0.18\bin` and all python scripts installed to FreeCAD's python's site-packages. 
 
 As conda build and packaging is working properly on windows, this option will not be explored
 
@@ -144,11 +144,11 @@ https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-
 
 pppParallelTests.exe  assertion failed, due to file path problem, solved 
 
-pppAppTests.exe can be debugged now, due to API different on Windows and Linux,  it is sovled by conditional compiling
+pppAppTests.exe can be debugged now, due to API different on Windows and Linux,  it is solved by conditional compiling
 > __forceinline errno_t __cdecl gmtime_s(struct tm *_Tm, const time_t *_Time) { return _gmtime64_s(_Tm, _Time); }
 
 `pppGeomTests.exe`  no output, no error message. 
-`pppGeomTests.exe` does not even enter running mode, in vs code, launch.json, set ` "stopAtEntry": true,`,  if there is still no output in debug console, it may means opencascade dll incompatabile. 
+`pppGeomTests.exe` does not even enter running mode, in vs code, launch.json, set ` "stopAtEntry": true,`,  if there is still no output in debug console, it may means opencascade dll incompatible. 
 if dll is not found, there should be a warning  dialog and give the missing dll name. 
 
 Is that because, visual studio 2019 compiled PPP and visual studio 2017 built OpenCASCADE DLL has some comptable issue?
@@ -169,4 +169,4 @@ even with visual studio 2019 compiler, there is no problem running all unit test
 
 
 #### IF using FreeCAD libpack  (skipped)
-FreeCAD/bin has all DLL neeeed  (if dll version is same, FreeCAD 0.18.4 used OCCT 7.3), but is not a good idea, get into PATH
+FreeCAD/bin has all DLL needed  (if dll version is same, FreeCAD 0.18.4 used OCCT 7.3), but is not a good idea, get into PATH

--- a/wiki/Contribution.md
+++ b/wiki/Contribution.md
@@ -43,9 +43,9 @@ By putting in PR, it is assumed contributor(s) **give the maintainer the legal r
 
 ### License consideration
 
-This parallel-preprocessor project is open source under the  LGPL v2.1 instead of LGPL v3, because all relevant projects, OCCT, salome, FreeCAD, are using LGPL v2.1. Meanwhile, LGPL v3 and LGPL v2.1 is not fully compatible to mixed up in source code level. In order to be co-operative with other relavent projects to build up an open source  CAD-CAE automated workflow, the same license LGPLv2.1 is adopted. 
+This parallel-preprocessor project is open source under the  LGPL v2.1 instead of LGPL v3, because all relevant projects, OCCT, salome, FreeCAD, are using LGPL v2.1. Meanwhile, LGPL v3 and LGPL v2.1 is not fully compatible to mixed up in source code level. In order to be co-operative with other relevant projects to build up an open source  CAD-CAE automated workflow, the same license LGPLv2.1 is adopted. 
 
-In the future, this project may be released in a new open source licese, or even dual license, if relicense may benefit the project sustainability. 
+In the future, this project may be released in a new open source license, or even dual license, if relicense may benefit the project sustainability. 
 
 
 

--- a/wiki/DeveloperGuide.md
+++ b/wiki/DeveloperGuide.md
@@ -40,7 +40,7 @@
 
 - Qt style naming, function name begins with lower case letter, diff from OCCT, VTK
 - private or protected class member is named as myVariable it is OCCT style
-- clang-format for auto formating, default LLVM
+- clang-format for auto formatting, default LLVM
 - spell check: command line can be made into git hook or vscode task
 - code guideline/standard: https://github.com/qingfengxia/awesome-cpp#coding-style
 

--- a/wiki/Documentation.md
+++ b/wiki/Documentation.md
@@ -20,7 +20,7 @@ see the [github workflows CI file](../.github/workflows/github-ci.yml) for detai
 
 ### Online documentation hosting
 
-Only the upstream repo should host the documenation. Go to the upstream's setting page:
+Only the upstream repo should host the documentation. Go to the upstream's setting page:
 https://github.com/ukaea/parallel-preprocessor/settings
 
 Scroll down to the "Github Pages", by select the correct branch hosting the documents, then github pages will be enabled after **save**.

--- a/wiki/Packaging.md
+++ b/wiki/Packaging.md
@@ -14,13 +14,13 @@ Inside the build folder, run  `make package` to generate *.deb or *.rpm.
 
 The generated packages is a all-in-one package include all (lib, bin, python module, headers).
 
-For exampel, unzip the deb package file, all installed files are organzied in subfolders 'bin/', 'lib/', 'include/'
+For example, unzip the deb package file, all installed files are organized in subfolders 'bin/', 'lib/', 'include/'
 - Binaries,  executables
 - Headers,  by PUBLIC_HEADER DESTINATION include/Geom
 - Library, shared libraries like `libpppGeom.so`
 - Python interface module
 
-If system-wide python3 (installed from official repository) is used, which can be confirmed by `which python3`,  this ded/rpm will have the correct python interface module installed.
+If system-wide python3 (installed from official repository) is used, which can be confirmed by `which python3`,  this deb/rpm will have the correct python interface module installed.
 
 Note: this fold structure does not work on windows
 

--- a/wiki/ParallelDesign.md
+++ b/wiki/ParallelDesign.md
@@ -22,7 +22,7 @@ https://nifi.apache.org/docs/nifi-docs/html/user-guide.html#User_Interface
 
 `Cpp-Taskflow` library is by far a faster, more expressive, and easier for drop-in integration for the single-way linear task programming.
 
-Libraries such as `OpenMP Tasking` and `Intel TBB FlowGraph` in handling complex parallel workloads. TensorFlow has the concept of graph simplication. 
+Libraries such as `OpenMP Tasking` and `Intel TBB FlowGraph` in handling complex parallel workloads. TensorFlow has the concept of graph simplification. 
 
 
 > OpenCV 4.x introduces very different programming model `G-API`, where you define pipeline of operations to be performed first, and then apply this pipeline to some actual data. In other words, whenever you call OpenCV G-API function, execution is deferred (lazily-evaluated), and deferred operation result is being returned instead of actual computation result. This concept might sound very similar to [C++ 20 Range V3](https://github.com/ericniebler/range-v3).  Source: https://blog.conan.io/2018/12/19/New-OpenCV-release-4-0.html
@@ -39,7 +39,7 @@ Currently, only CPU device is supported, although GPU acceleration will be consi
 + MPI (distributive, NUMA)
   This is useful for distributive meshing, since memory capacity on a single multi-core node may be not sufficient to mesh large assemblies.
 
-+ GPU (heterogenous)
++ GPU (heterogeneous)
   This is the preferred for simple data types such as image processing AI. 
 
 ## Concurrent data access
@@ -55,7 +55,7 @@ The main thread allocate the `std::vector<>` with enough size by `resize(capacit
   `template <class T> using VectorType = std::vector<T>;`
 
 ### Concurrent data structure
-There are high-level concurent data structure with lock/synchronization underneath
+There are high-level concurrent data structure with lock/synchronization underneath
 
 <https://github.com/FEniCS/dolfin/tree/master/dolfin/la>
 

--- a/wiki/PortToWindows.md
+++ b/wiki/PortToWindows.md
@@ -4,7 +4,7 @@ This document records some notes on porting parallel-preprocessor to Windows 10
 
 ### Platform C++ runtime difference
 
-C++ demangle, needs boost if using msvc comppiler
+C++ demangle, needs boost if using msvc compiler
 
 Windows has no complete "signal.h" support. 
 ```c++
@@ -15,7 +15,7 @@ sigemptyset()   // no such on windows? mingw32?
 ### mingw32-w64 v8.1 compiler
 
 mingw has problem with filesystem, and there is no easy solution. and As the official OpenCASCADE has been built with  VC141 (VS2017)
-The binary compatibility of mingw and visual C++ is doubtable in produciton scenarion.  
+The binary compatibility of mingw and visual C++ is doubtable in production scenario.  
 
 https://github.com/mxe/mxe/issues/2220
 the gcc 9 patch seems to fix this issue
@@ -97,7 +97,7 @@ if(WIN32)
 endif()
 ```
 
-with this definition, cmake can geneate pppApp.lib, but it is not in the output lib folder `lib` ,  but in another folder in the build directory `PPP/pppApp.lib`
+with this definition, cmake can generate pppApp.lib, but it is not in the output lib folder `lib` ,  but in another folder in the build directory `PPP/pppApp.lib`
 TODO: let cmake collect those *.lib and put into lib output folder. 
 
 for header only library, that is not necessary? 
@@ -136,11 +136,11 @@ static variable may cause some trouble.
 #### for template class 
 There is no need to specify `__declspec(dllexport)`, since template class impl usually in header file. 
 
-> A template will only be compiled with spedified template parameter. Thus there will be nothing in the dll to link against.
+> A template will only be compiled with specified template parameter. Thus there will be nothing in the dll to link against.
   In order to use a template you always need to include both: declaration and definition. You cannot put the definitions in a .cpp file like ordinary classes/functions. 
   http://www.cplusplus.com/forum/windows/199689/
 
-If moving impl into cpp file, got misisng symbol error, when used by another target/module.
+If moving impl into cpp file, got missing symbol error, when used by another target/module.
 
 https://stackoverflow.com/questions/17519879/visual-studio-dll-export-issue-for-class-and-function-template-instantiations
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -55,10 +55,10 @@ Currently package does not include test data in the `data/` folder, because it i
 ### Geometry preprocessing operations:
 Note: each task is worth of a journal paper, so it will not be available soon.
    - parallel enclosure, section operations (assuming geometry is valid, boolean operation will not fail)
-   - geometry fixing (geometry data may not valid to perform boolean operaton)
+   - geometry fixing (geometry data may not valid to perform boolean operation)
 
    - parallel geometry merging (currently imprint has been parallelized, but merging on single thread)
-   - water-fill: for a given assembly, construct a shape for teh volume that water can fill
+   - water-fill: for a given assembly, construct a shape for the volume that water can fill
 
 ## Planned features in the long term
 


### PR DESCRIPTION
Found via `codespell -q 3 -S ./third-party,./src/Geom -L anumber,oce,te,thes,xwindows`

Checklist
- [x] Source is rebased on latest `upstream main` so is mergeable automatically or easily merged even with confliction.
- [x] Title of this PR is meaningful: e.g. "fix issue #8 geomPipeline.py -o does not work", not "fix geomPipeline.py"
- [x] Commit message is meaningful:  `git push origin +your_branch` to squash some tiny fixes for CI failures
- [x] Give the maintainer the legal rights to change the open source license in the future (see wiki/Contribution.md) for details


